### PR TITLE
Fix/public did mediator routing keys

### DIFF
--- a/aries_cloudagent/messaging/jsonld/routes.py
+++ b/aries_cloudagent/messaging/jsonld/routes.py
@@ -5,7 +5,6 @@ from aiohttp_apispec import docs, request_schema, response_schema
 from marshmallow import INCLUDE, Schema, fields
 from pydid.verification_method import (
     Ed25519VerificationKey2018,
-    KnownVerificationMethods,
 )
 
 from ...admin.request_context import AdminRequestContext
@@ -148,7 +147,6 @@ async def verify(request: web.BaseRequest):
                 vmethod = await resolver.dereference(
                     profile,
                     doc["proof"]["verificationMethod"],
-                    cls=KnownVerificationMethods,
                 )
 
                 if not isinstance(vmethod, SUPPORTED_VERIFICATION_METHOD_TYPES):

--- a/aries_cloudagent/messaging/jsonld/tests/test_routes.py
+++ b/aries_cloudagent/messaging/jsonld/tests/test_routes.py
@@ -234,22 +234,22 @@ async def test_verify_bad_ver_meth_deref_req_error(
     assert "error" in mock_response.call_args[0][0]
 
 
-@pytest.mark.asyncio
-async def test_verify_bad_ver_meth_not_ver_meth(
-    mock_resolver, mock_verify_request, mock_response, request_body
-):
-    request_body["doc"]["proof"][
-        "verificationMethod"
-    ] = "did:example:1234abcd#did-communication"
-    await test_module.verify(mock_verify_request(request_body))
-    assert "error" in mock_response.call_args[0][0]
-
-
+@pytest.mark.parametrize(
+    "vmethod",
+    [
+        "did:example:1234abcd#key-2",
+        "did:example:1234abcd#did-communication",
+    ],
+)
 @pytest.mark.asyncio
 async def test_verify_bad_vmethod_unsupported(
-    mock_resolver, mock_verify_request, mock_response, request_body
+    mock_resolver,
+    mock_verify_request,
+    mock_response,
+    request_body,
+    vmethod,
 ):
-    request_body["doc"]["proof"]["verificationMethod"] = "did:example:1234abcd#key-2"
+    request_body["doc"]["proof"]["verificationMethod"] = vmethod
     with pytest.raises(web.HTTPBadRequest):
         await test_module.verify(mock_verify_request(request_body))
 

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
@@ -2068,6 +2068,9 @@ class TestConnectionManager(AsyncTestCase):
                 return_value=self.test_endpoint
             )
             self.resolver.resolve = async_mock.CoroutineMock(return_value=did_doc)
+            self.resolver.dereference = async_mock.CoroutineMock(
+                return_value = did_doc.verification_method[0]
+            )
             self.context.injector.bind_instance(DIDResolver, self.resolver)
 
             local_did = await session.wallet.create_local_did(
@@ -2137,6 +2140,9 @@ class TestConnectionManager(AsyncTestCase):
                 return_value=self.test_endpoint
             )
             self.resolver.resolve = async_mock.CoroutineMock(return_value=did_doc)
+            self.resolver.dereference = async_mock.CoroutineMock(
+                return_value = did_doc.verification_method[0]
+            )
             self.context.injector.bind_instance(DIDResolver, self.resolver)
             local_did = await session.wallet.create_local_did(
                 method=DIDMethod.SOV,
@@ -2288,6 +2294,9 @@ class TestConnectionManager(AsyncTestCase):
                 return_value=self.test_endpoint
             )
             self.resolver.resolve = async_mock.CoroutineMock(return_value=did_doc)
+            self.resolver.dereference = async_mock.CoroutineMock(
+                return_value = did_doc.verification_method[0]
+            )
             self.context.injector.bind_instance(DIDResolver, self.resolver)
             local_did = await session.wallet.create_local_did(
                 method=DIDMethod.SOV,
@@ -2357,6 +2366,9 @@ class TestConnectionManager(AsyncTestCase):
 
             self.resolver = async_mock.MagicMock()
             self.resolver.resolve = async_mock.CoroutineMock(return_value=did_doc)
+            self.resolver.dereference = async_mock.CoroutineMock(
+                return_value = did_doc.verification_method[0]
+            )
             self.context.injector.bind_instance(DIDResolver, self.resolver)
 
             local_did = await session.wallet.create_local_did(

--- a/aries_cloudagent/resolver/default/tests/test_indy.py
+++ b/aries_cloudagent/resolver/default/tests/test_indy.py
@@ -17,7 +17,7 @@ from ....multitenant.base import BaseMultitenantManager
 from ....multitenant.manager import MultitenantManager
 
 from ...base import DIDNotFound, ResolverError
-from ..indy import IndyDIDResolver
+from ..indy import IndyDIDResolver, _routing_keys_as_did_key_urls
 
 # pylint: disable=W0621
 TEST_DID0 = "did:sov:WgWxqztrNooG92RXvxSTWv"
@@ -127,7 +127,7 @@ class TestIndyResolver:
         """Test that new attrib structure is supported."""
         example = {
             "endpoint": "https://example.com/endpoint",
-            "routingKeys": ["a-routing-key"],
+            "routingKeys": ["HQhjaj4mcaS3Xci27a9QhnBrNpS91VNFUU4TDrtMxa9j"],
             "types": ["DIDComm", "did-communication", "endpoint"],
             "profile": "https://example.com",
             "linked_domains": "https://example.com",
@@ -177,3 +177,18 @@ class TestIndyResolver:
     )
     def test_process_endpoint_types(self, resolver: IndyDIDResolver, types, result):
         assert resolver.process_endpoint_types(types) == result
+
+    @pytest.mark.parametrize(
+        "keys",
+        [
+            ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
+            ["did:key:z6MkgzZFYHiH9RhyMmkoyvNvVwnvgLxkVrJbureLx9HXsuKA"],
+            [
+                "did:key:z6MkgzZFYHiH9RhyMmkoyvNvVwnvgLxkVrJbureLx9HXsuKA#z6MkgzZFYHiH9RhyMmkoyvNvVwnvgLxkVrJbureLx9HXsuKA"
+            ],
+        ],
+    )
+    def test_routing_keys_as_did_key_urls(self, keys):
+        for key in _routing_keys_as_did_key_urls(keys):
+            assert key.startswith("did:key:")
+            assert "#" in key

--- a/aries_cloudagent/resolver/tests/test_did_resolver.py
+++ b/aries_cloudagent/resolver/tests/test_did_resolver.py
@@ -7,7 +7,7 @@ import re
 import pytest
 
 from asynctest import mock as async_mock
-from pydid import DID, DIDDocument, VerificationMethod
+from pydid import DID, DIDDocument, VerificationMethod, BasicDIDDocument
 
 from ..base import (
     BaseDIDResolver,
@@ -151,6 +151,17 @@ async def test_dereference(resolver, profile):
     expected: dict = DOC["verificationMethod"][0]
     actual: VerificationMethod = await resolver.dereference(profile, url)
     assert expected == actual.serialize()
+
+
+@pytest.mark.asyncio
+async def test_dereference_diddoc(resolver, profile):
+    url = "did:example:1234abcd#4"
+    doc = BasicDIDDocument(
+        id="did:example:z6Mkmpe2DyE4NsDiAb58d75hpi1BjqbH6wYMschUkjWDEEuR"
+    )
+    result = await resolver.dereference(profile, url, document=doc)
+    assert isinstance(result, VerificationMethod)
+    assert result.id == url
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR adds and fixes unit tests related to the changes in `DIDResolver.dereference()` and `_routing_keys_as_did_key_urls()` and ensures that a did:key passed into `_routing_keys_as_did_key_urls()` is converted into a did:key URL.