### PR TITLE
fix: account for changes to KeyType

### DIFF
--- a/aries_cloudagent/resolver/default/indy.py
+++ b/aries_cloudagent/resolver/default/indy.py
@@ -20,7 +20,7 @@ from ...ledger.multiple_ledger.ledger_requests_executor import (
 )
 from ...messaging.valid import IndyDID
 from ...multitenant.base import BaseMultitenantManager
-from ...wallet.key_type import KeyType
+from ...wallet.key_type import ED25519
 from ..base import BaseDIDResolver, DIDNotFound, ResolverError, ResolverType
 
 LOGGER = logging.getLogger(__name__)
@@ -39,9 +39,10 @@ def _routing_keys_as_did_key_urls(routing_keys: Sequence[str]) -> Sequence[str]:
     did_key_urls = []
     for routing_key in routing_keys:
         if not routing_key.startswith("did:key:"):
-            did_key_urls.append(
-                DIDKey.from_public_key_b58(routing_key, KeyType.ED25519).key_id
-            )
+            did_key_urls.append(DIDKey.from_public_key_b58(routing_key, ED25519).key_id)
+            # NOTE: using hardcoded prefix ED25519 because py_multicodec library
+            # is outdated. Update after this PR gets released:
+            # https://github.com/multiformats/py-multicodec/pull/14
         else:
             if "#" not in routing_key:
                 did_key_urls.append(

--- a/aries_cloudagent/resolver/default/indy.py
+++ b/aries_cloudagent/resolver/default/indy.py
@@ -40,9 +40,6 @@ def _routing_keys_as_did_key_urls(routing_keys: Sequence[str]) -> Sequence[str]:
     for routing_key in routing_keys:
         if not routing_key.startswith("did:key:"):
             did_key_urls.append(DIDKey.from_public_key_b58(routing_key, ED25519).key_id)
-            # NOTE: using hardcoded prefix ED25519 because py_multicodec library
-            # is outdated. Update after this PR gets released:
-            # https://github.com/multiformats/py-multicodec/pull/14
         else:
             if "#" not in routing_key:
                 did_key_urls.append(


### PR DESCRIPTION
This PR adjusts the `IndyDIDResolver` to account for changes to the `KeyType` class. 

Note in `key_type.py` file:
> The py_multicodec library is outdated. We use hardcoded prefixes here until this PR gets released: https://github.com/multiformats/py-multicodec/pull/14. Multicodec is also not used now, but may be used again if py_multicodec is updated.

Signed-off-by: Char Howland <char@indicio.tech>